### PR TITLE
[#526] fix(wrapper-generator): fix reading 'actions' dir when suggesting versions

### DIFF
--- a/.github/workflows/actions-versions.main.kts
+++ b/.github/workflows/actions-versions.main.kts
@@ -42,7 +42,7 @@ workflow(
             name = "Create issue",
             action = CreateIssueFromFileV4(
                 title = "Updates available",
-                contentFilepath = "wrapper-generator/build/suggestVersions.md",
+                contentFilepath = "build/suggestVersions.md",
             )
         )
     }

--- a/.github/workflows/actions-versions.yaml
+++ b/.github/workflows/actions-versions.yaml
@@ -50,4 +50,4 @@ jobs:
       uses: peter-evans/create-issue-from-file@v4
       with:
         title: Updates available
-        content-filepath: wrapper-generator/build/suggestVersions.md
+        content-filepath: build/suggestVersions.md

--- a/wrapper-generator/build.gradle.kts
+++ b/wrapper-generator/build.gradle.kts
@@ -26,6 +26,7 @@ tasks.run.configure {
 tasks.register<JavaExec>("suggestVersions") {
     classpath = sourceSets["main"].runtimeClasspath
     mainClass.set("it.krzeminski.githubactions.wrappergenerator.versions.SuggestVersionsKt")
+    workingDir = rootDir
     dependsOn(tasks.compileKotlin)
 }
 


### PR DESCRIPTION
Closes #526.