### PR TITLE
build: fix plugin version

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
     // Code quality.
     id("io.gitlab.arturbosch.detekt")
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.12.1"
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.12.0"
 }
 
 group = "it.krzeminski"


### PR DESCRIPTION
With the latest version of the plugin `binary-compatibility-validator` I can't do even a `./gradlew help`

> Could not download binary-compatibility-validator-0.12.1.jar (org.jetbrains.kotlinx:binary-compatibility-validator:0.12.1)
https://scans.gradle.com/s/ymfeu563hrxfc/failure#1