### PR TITLE
[#605] fix(library): use JRE 17 in consistency check job

### DIFF
--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -1,6 +1,7 @@
 package it.krzeminski.githubactions.yaml
 
 import it.krzeminski.githubactions.actions.actions.CheckoutV3
+import it.krzeminski.githubactions.actions.actions.SetupJavaV3
 import it.krzeminski.githubactions.domain.Job
 import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
 import it.krzeminski.githubactions.domain.Workflow
@@ -49,6 +50,17 @@ private fun Workflow.generateYaml(addConsistencyCheck: Boolean, useGitDiff: Bool
             condition = yamlConsistencyJobCondition,
         ) {
             uses("Check out", CheckoutV3())
+            // GitHub Actions runner come preinstalled with some Java versions, but isn't guaranteed to fit the bytecode
+            // version used to compile the library that is used in the consistency check. Hence we install the required
+            // version explicitly.
+            uses(
+                name = "Set up Java in proper version",
+                action = SetupJavaV3(
+                    javaVersion = "17",
+                    distribution = SetupJavaV3.Distribution.Zulu,
+                    cache = SetupJavaV3.BuildPlatform.Gradle,
+                ),
+            )
             if (useGitDiff) {
                 run(
                     "Execute script",

--- a/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
@@ -61,6 +61,13 @@ class IntegrationTest : FunSpec({
                   name: Check out
                   uses: actions/checkout@v3
                 - id: step-1
+                  name: Set up Java in proper version
+                  uses: actions/setup-java@v3
+                  with:
+                    java-version: 17
+                    distribution: zulu
+                    cache: gradle
+                - id: step-2
                   name: Consistency check
                   run: diff -u '.github/workflows/some_workflow.yaml' <('.github/workflows/some_workflow.main.kts')
               test_job:
@@ -212,9 +219,16 @@ class IntegrationTest : FunSpec({
                   name: Check out
                   uses: actions/checkout@v3
                 - id: step-1
+                  name: Set up Java in proper version
+                  uses: actions/setup-java@v3
+                  with:
+                    java-version: 17
+                    distribution: zulu
+                    cache: gradle
+                - id: step-2
                   name: Execute script
                   run: rm '.github/workflows/some_workflow.yaml' && '.github/workflows/some_workflow.main.kts'
-                - id: step-2
+                - id: step-3
                   name: Consistency check
                   run: git diff --exit-code '.github/workflows/some_workflow.yaml'
               test_job:
@@ -580,6 +594,13 @@ class IntegrationTest : FunSpec({
                   name: Check out
                   uses: actions/checkout@v3
                 - id: step-1
+                  name: Set up Java in proper version
+                  uses: actions/setup-java@v3
+                  with:
+                    java-version: 17
+                    distribution: zulu
+                    cache: gradle
+                - id: step-2
                   name: Consistency check
                   run: diff -u '.github/workflows/some_workflow.yaml' <('.github/workflows/some_workflow.main.kts')
               test_job:


### PR DESCRIPTION
JRE 11 is the default one in the Ubuntu image of GitHub Actions runner. It's wrong since we started compiling to JRE 17 bytecode. Let's use 17 explicitly.