### PR TITLE
[#623] fix(library)!: put jobs and steps as last attributes

### DIFF
--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/JobsToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/JobsToYaml.kt
@@ -42,8 +42,8 @@ private fun Job<*>.toYaml(): Map<String, Any> =
         },
         "timeout-minutes" to timeoutMinutes,
         "outputs" to outputs.outputMapping.ifEmpty { null },
-        "steps" to steps.stepsToYaml(),
         *_customArguments.toList().toTypedArray(),
+        "steps" to steps.stepsToYaml(),
     )
 
 @InternalGithubActionsApi

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -110,6 +110,6 @@ private fun Workflow.toYamlInternal(jobsWithConsistencyCheck: List<Job<*>>): Map
             )
         },
         "env" to env.ifEmpty { null },
-        "jobs" to jobsWithConsistencyCheck.jobsToYaml(),
         *_customArguments.toList().toTypedArray(),
+        "jobs" to jobsWithConsistencyCheck.jobsToYaml(),
     )

--- a/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
@@ -293,6 +293,9 @@ class IntegrationTest : FunSpec({
                         hello! job
                     """.trimIndent(),
                 ),
+                _customArguments = mapOf(
+                    "baz-goo" to 123,
+                ),
             ) {
                 uses(
                     name = "Check out",
@@ -339,6 +342,7 @@ class IntegrationTest : FunSpec({
                 hey,
                 hi,
                 hello! workflow
+            foo-bar: baz
             jobs:
               test_job:
                 runs-on: ubuntu-latest
@@ -349,6 +353,7 @@ class IntegrationTest : FunSpec({
                     hi,
                     hello! job
                 if: ${'$'}{{ always() }}
+                baz-goo: 123
                 steps:
                 - id: step-0
                   name: Check out
@@ -370,7 +375,6 @@ class IntegrationTest : FunSpec({
                       hello! run
                   continue-on-error: true
                   run: echo 'hello!'
-            foo-bar: baz
 
         """.trimIndent()
     }


### PR DESCRIPTION
It intuitively makes sense to have a collection of jobs (for workflows) and a collection of steps (for jobs) as very last items. It's unlikely for `_customArguments` to contain values that would be a better fit for last attributes.