### PR TITLE
chore(library): don't specify JVM vendor

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -33,7 +33,6 @@ kotlin {
 
 fun JavaToolchainSpec.requiredJdkVersion() {
     languageVersion.set(JavaLanguageVersion.of(17))
-    vendor.set(JvmVendorSpec.AZUL)
 }
 
 tasks.withType<KotlinCompile> {


### PR DESCRIPTION
By specifying it, it enforces contributors to have it installed. It's possible to install it quickly using Gradle Toolchains, but still there is no reason to enforce any specific vendor. Let's remove it for simplicity.

Triggered by https://kotlinlang.slack.com/archives/C02UUATR7RC/p1674164513261249