### PR TITLE
[#637] fix(library)!: go back to using JRE 11

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -39,7 +39,9 @@ tasks.withType<KotlinCompile> {
     kotlinOptions {
         apiVersion = "1.5"
         languageVersion = "1.7"
-        jvmTarget = "17"
+
+        // It's available without extra setup on GitHub Actions runners.
+        jvmTarget = "11"
 
         allWarningsAsErrors = true
 

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -1,7 +1,6 @@
 package it.krzeminski.githubactions.yaml
 
 import it.krzeminski.githubactions.actions.actions.CheckoutV3
-import it.krzeminski.githubactions.actions.actions.SetupJavaV3
 import it.krzeminski.githubactions.domain.Job
 import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
 import it.krzeminski.githubactions.domain.Workflow
@@ -50,17 +49,6 @@ private fun Workflow.generateYaml(addConsistencyCheck: Boolean, useGitDiff: Bool
             condition = yamlConsistencyJobCondition,
         ) {
             uses("Check out", CheckoutV3())
-            // GitHub Actions runner come preinstalled with some Java versions, but isn't guaranteed to fit the bytecode
-            // version used to compile the library that is used in the consistency check. Hence we install the required
-            // version explicitly.
-            uses(
-                name = "Set up Java in proper version",
-                action = SetupJavaV3(
-                    javaVersion = "17",
-                    distribution = SetupJavaV3.Distribution.Zulu,
-                    cache = SetupJavaV3.BuildPlatform.Gradle,
-                ),
-            )
             if (useGitDiff) {
                 run(
                     "Execute script",

--- a/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
@@ -62,13 +62,6 @@ class IntegrationTest : FunSpec({
                   name: Check out
                   uses: actions/checkout@v3
                 - id: step-1
-                  name: Set up Java in proper version
-                  uses: actions/setup-java@v3
-                  with:
-                    java-version: 17
-                    distribution: zulu
-                    cache: gradle
-                - id: step-2
                   name: Consistency check
                   run: diff -u '.github/workflows/some_workflow.yaml' <('.github/workflows/some_workflow.main.kts')
               test_job:
@@ -220,16 +213,9 @@ class IntegrationTest : FunSpec({
                   name: Check out
                   uses: actions/checkout@v3
                 - id: step-1
-                  name: Set up Java in proper version
-                  uses: actions/setup-java@v3
-                  with:
-                    java-version: 17
-                    distribution: zulu
-                    cache: gradle
-                - id: step-2
                   name: Execute script
                   run: rm '.github/workflows/some_workflow.yaml' && '.github/workflows/some_workflow.main.kts'
-                - id: step-3
+                - id: step-2
                   name: Consistency check
                   run: git diff --exit-code '.github/workflows/some_workflow.yaml'
               test_job:
@@ -678,13 +664,6 @@ class IntegrationTest : FunSpec({
                   name: Check out
                   uses: actions/checkout@v3
                 - id: step-1
-                  name: Set up Java in proper version
-                  uses: actions/setup-java@v3
-                  with:
-                    java-version: 17
-                    distribution: zulu
-                    cache: gradle
-                - id: step-2
                   name: Consistency check
                   run: diff -u '.github/workflows/some_workflow.yaml' <('.github/workflows/some_workflow.main.kts')
               test_job:


### PR DESCRIPTION
The library doesn't really need any features that aren't present in Java 11. Thanks to this simplification, the consistency check job becomes faster again thanks to no need to set up another Java - Java 11 is available by default on GitHub Actions runners.