### PR TITLE
ci: fail on warnings in Kotlin scripts

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -58,7 +58,7 @@ workflow(
             find -name *.main.kts -print0 | while read -d ${'$'}'\0' file
             do
                 echo "Compiling ${'$'}file..."
-                kotlinc "${'$'}file"
+                kotlinc -Werror -Xallow-any-scripts-in-source-roots "${'$'}file"
             done
             """.trimIndent()
         )

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
         find -name *.main.kts -print0 | while read -d $'\0' file
         do
             echo "Compiling $file..."
-            kotlinc "$file"
+            kotlinc -Werror -Xallow-any-scripts-in-source-roots "$file"
         done
   workflows_consistency_check:
     name: Run consistency check on all GitHub workflows


### PR DESCRIPTION
It will no only help find certain bugs, but will also fail if the workflows
use outdated action versions.