### PR TITLE
Custom Preamble Improvements

### DIFF
--- a/library/api/library.api
+++ b/library/api/library.api
@@ -1526,23 +1526,6 @@ public final class it/krzeminski/githubactions/dsl/JobBuilder : it/krzeminski/gi
 	public static synthetic fun uses$default (Lit/krzeminski/githubactions/dsl/JobBuilder;Ljava/lang/String;Lit/krzeminski/githubactions/actions/ActionWithOutputs;Ljava/util/LinkedHashMap;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Map;ILjava/lang/Object;)Lit/krzeminski/githubactions/domain/ExternalActionStepWithOutputs;
 }
 
-public abstract class it/krzeminski/githubactions/dsl/Preamble {
-	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getContent ()Ljava/lang/String;
-}
-
-public final class it/krzeminski/githubactions/dsl/Preamble$Just : it/krzeminski/githubactions/dsl/Preamble {
-	public fun <init> (Ljava/lang/String;)V
-}
-
-public final class it/krzeminski/githubactions/dsl/Preamble$WithOriginalAfter : it/krzeminski/githubactions/dsl/Preamble {
-	public fun <init> (Ljava/lang/String;)V
-}
-
-public final class it/krzeminski/githubactions/dsl/Preamble$WithOriginalBefore : it/krzeminski/githubactions/dsl/Preamble {
-	public fun <init> (Ljava/lang/String;)V
-}
-
 public final class it/krzeminski/githubactions/dsl/WorkflowBuilder {
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/LinkedHashMap;Ljava/nio/file/Path;Ljava/lang/String;Lit/krzeminski/githubactions/domain/Concurrency;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/LinkedHashMap;Ljava/nio/file/Path;Ljava/lang/String;Lit/krzeminski/githubactions/domain/Concurrency;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -2775,11 +2758,28 @@ public final class it/krzeminski/githubactions/yaml/JobsToYamlKt {
 	public static final fun toYaml (Lit/krzeminski/githubactions/domain/RunnerType;)Ljava/lang/String;
 }
 
+public abstract class it/krzeminski/githubactions/yaml/Preamble {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getContent ()Ljava/lang/String;
+}
+
+public final class it/krzeminski/githubactions/yaml/Preamble$Just : it/krzeminski/githubactions/yaml/Preamble {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class it/krzeminski/githubactions/yaml/Preamble$WithOriginalAfter : it/krzeminski/githubactions/yaml/Preamble {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class it/krzeminski/githubactions/yaml/Preamble$WithOriginalBefore : it/krzeminski/githubactions/yaml/Preamble {
+	public fun <init> (Ljava/lang/String;)V
+}
+
 public final class it/krzeminski/githubactions/yaml/ToYamlKt {
-	public static final fun toYaml (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/dsl/Preamble;)Ljava/lang/String;
-	public static synthetic fun toYaml$default (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/dsl/Preamble;ILjava/lang/Object;)Ljava/lang/String;
-	public static final fun writeToFile (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/dsl/Preamble;)V
-	public static synthetic fun writeToFile$default (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/dsl/Preamble;ILjava/lang/Object;)V
+	public static final fun toYaml (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/yaml/Preamble;)Ljava/lang/String;
+	public static synthetic fun toYaml$default (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/yaml/Preamble;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun writeToFile (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/yaml/Preamble;)V
+	public static synthetic fun writeToFile$default (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/yaml/Preamble;ILjava/lang/Object;)V
 }
 
 public final class it/krzeminski/githubactions/yaml/TriggersToYamlKt {

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -1526,6 +1526,23 @@ public final class it/krzeminski/githubactions/dsl/JobBuilder : it/krzeminski/gi
 	public static synthetic fun uses$default (Lit/krzeminski/githubactions/dsl/JobBuilder;Ljava/lang/String;Lit/krzeminski/githubactions/actions/ActionWithOutputs;Ljava/util/LinkedHashMap;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Map;ILjava/lang/Object;)Lit/krzeminski/githubactions/domain/ExternalActionStepWithOutputs;
 }
 
+public abstract class it/krzeminski/githubactions/dsl/Preamble {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getContent ()Ljava/lang/String;
+}
+
+public final class it/krzeminski/githubactions/dsl/Preamble$Just : it/krzeminski/githubactions/dsl/Preamble {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class it/krzeminski/githubactions/dsl/Preamble$WithOriginalAfter : it/krzeminski/githubactions/dsl/Preamble {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class it/krzeminski/githubactions/dsl/Preamble$WithOriginalBefore : it/krzeminski/githubactions/dsl/Preamble {
+	public fun <init> (Ljava/lang/String;)V
+}
+
 public final class it/krzeminski/githubactions/dsl/WorkflowBuilder {
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/LinkedHashMap;Ljava/nio/file/Path;Ljava/lang/String;Lit/krzeminski/githubactions/domain/Concurrency;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/LinkedHashMap;Ljava/nio/file/Path;Ljava/lang/String;Lit/krzeminski/githubactions/domain/Concurrency;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -2759,10 +2776,10 @@ public final class it/krzeminski/githubactions/yaml/JobsToYamlKt {
 }
 
 public final class it/krzeminski/githubactions/yaml/ToYamlKt {
-	public static final fun toYaml (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Ljava/lang/String;)Ljava/lang/String;
-	public static synthetic fun toYaml$default (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
-	public static final fun writeToFile (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Ljava/lang/String;)V
-	public static synthetic fun writeToFile$default (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Ljava/lang/String;ILjava/lang/Object;)V
+	public static final fun toYaml (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/dsl/Preamble;)Ljava/lang/String;
+	public static synthetic fun toYaml$default (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/dsl/Preamble;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun writeToFile (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/dsl/Preamble;)V
+	public static synthetic fun writeToFile$default (Lit/krzeminski/githubactions/domain/Workflow;ZLjava/nio/file/Path;Lit/krzeminski/githubactions/dsl/Preamble;ILjava/lang/Object;)V
 }
 
 public final class it/krzeminski/githubactions/yaml/TriggersToYamlKt {

--- a/library/src/main/kotlin/it/krzeminski/githubactions/dsl/Preamble.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/dsl/Preamble.kt
@@ -1,0 +1,7 @@
+package it.krzeminski.githubactions.dsl
+
+public sealed class Preamble(public val content: String) {
+    public class Just(content: String) : Preamble(content)
+    public class WithOriginalBefore(content: String) : Preamble(content)
+    public class WithOriginalAfter(content: String) : Preamble(content)
+}

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/Preamble.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/Preamble.kt
@@ -1,4 +1,4 @@
-package it.krzeminski.githubactions.dsl
+package it.krzeminski.githubactions.yaml
 
 public sealed class Preamble(public val content: String) {
     public class Just(content: String) : Preamble(content)

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -55,7 +55,7 @@ private fun commentify(preamble: String): String {
 
     return preamble
         .lineSequence()
-        .joinToString("\n", postfix = "\n\n") { "# $it" }
+        .joinToString("\n", postfix = "\n\n") { if (it.isEmpty()) "#" else "# $it" }
 }
 
 @Suppress("LongMethod")

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -4,13 +4,12 @@ import it.krzeminski.githubactions.actions.actions.CheckoutV3
 import it.krzeminski.githubactions.domain.Job
 import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
 import it.krzeminski.githubactions.domain.Workflow
-import it.krzeminski.githubactions.dsl.Preamble
-import it.krzeminski.githubactions.dsl.Preamble.Just
-import it.krzeminski.githubactions.dsl.Preamble.WithOriginalAfter
-import it.krzeminski.githubactions.dsl.Preamble.WithOriginalBefore
 import it.krzeminski.githubactions.dsl.toBuilder
 import it.krzeminski.githubactions.internal.findGitRoot
 import it.krzeminski.githubactions.internal.relativeToAbsolute
+import it.krzeminski.githubactions.yaml.Preamble.Just
+import it.krzeminski.githubactions.yaml.Preamble.WithOriginalAfter
+import it.krzeminski.githubactions.yaml.Preamble.WithOriginalBefore
 import java.nio.file.Path
 import kotlin.io.path.absolute
 import kotlin.io.path.invariantSeparatorsPathString

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -4,6 +4,10 @@ import it.krzeminski.githubactions.actions.actions.CheckoutV3
 import it.krzeminski.githubactions.domain.Job
 import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
 import it.krzeminski.githubactions.domain.Workflow
+import it.krzeminski.githubactions.dsl.Preamble
+import it.krzeminski.githubactions.dsl.Preamble.Just
+import it.krzeminski.githubactions.dsl.Preamble.WithOriginalAfter
+import it.krzeminski.githubactions.dsl.Preamble.WithOriginalBefore
 import it.krzeminski.githubactions.dsl.toBuilder
 import it.krzeminski.githubactions.internal.findGitRoot
 import it.krzeminski.githubactions.internal.relativeToAbsolute
@@ -14,7 +18,7 @@ import kotlin.io.path.invariantSeparatorsPathString
 public fun Workflow.toYaml(
     addConsistencyCheck: Boolean = sourceFile != null,
     gitRootDir: Path? = sourceFile?.absolute()?.findGitRoot(),
-    preamble: String? = null,
+    preamble: Preamble? = null,
 ): String {
     return generateYaml(
         addConsistencyCheck = addConsistencyCheck,
@@ -27,7 +31,7 @@ public fun Workflow.toYaml(
 public fun Workflow.writeToFile(
     addConsistencyCheck: Boolean = sourceFile != null,
     gitRootDir: Path? = sourceFile?.absolute()?.findGitRoot(),
-    preamble: String? = null,
+    preamble: Preamble? = null,
 ) {
     checkNotNull(gitRootDir) {
         "gitRootDir must be specified explicitly when sourceFile is null"
@@ -55,7 +59,7 @@ private fun commentify(preamble: String): String {
 
     return preamble
         .lineSequence()
-        .joinToString("\n", postfix = "\n\n") { if (it.isEmpty()) "#" else "# $it" }
+        .joinToString("\n", postfix = "\n\n") { "# $it".trimEnd() }
 }
 
 @Suppress("LongMethod")
@@ -63,7 +67,7 @@ private fun Workflow.generateYaml(
     addConsistencyCheck: Boolean,
     useGitDiff: Boolean,
     gitRootDir: Path?,
-    preamble: String?,
+    preamble: Preamble?,
 ): String {
     val sourceFilePath = gitRootDir?.let {
         sourceFile?.relativeToAbsolute(gitRootDir)?.invariantSeparatorsPathString
@@ -113,24 +117,27 @@ private fun Workflow.generateYaml(
         jobs
     }
 
-    val computedPreamble = if (preamble != null) {
-        commentify(preamble)
-    } else if (sourceFilePath != null) {
-        """
-        # This file was generated using Kotlin DSL ($sourceFilePath).
-        # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-        # Generated with https://github.com/krzema12/github-workflows-kt
+    val originalPreamble = commentify(
+        if (sourceFilePath != null) {
+            """
+            This file was generated using Kotlin DSL ($sourceFilePath).
+            If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+            Generated with https://github.com/krzema12/github-workflows-kt
+            """.trimIndent()
+        } else {
+            """
+            This file was generated using a Kotlin DSL.
+            If you want to modify the workflow, please change the Kotlin source and regenerate this YAML file.
+            Generated with https://github.com/krzema12/github-workflows-kt
+            """.trimIndent()
+        },
+    )
 
-
-        """.trimIndent()
-    } else {
-        """
-        # This file was generated using a Kotlin DSL.
-        # If you want to modify the workflow, please change the Kotlin source and regenerate this YAML file.
-        # Generated with https://github.com/krzema12/github-workflows-kt
-
-
-        """.trimIndent()
+    val computedPreamble = when (preamble) {
+        is Just -> commentify(preamble.content)
+        is WithOriginalAfter -> commentify(preamble.content) + originalPreamble
+        is WithOriginalBefore -> originalPreamble + commentify(preamble.content)
+        null -> originalPreamble
     }
 
     val workflowToBeSerialized = this.toYamlInternal(jobsWithConsistencyCheck)

--- a/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
@@ -837,6 +837,33 @@ class IntegrationTest : FunSpec({
         """.trimIndent()
     }
 
+    test("toYaml() - custom preamble with empty line") {
+        val yaml = workflowWithoutSource.toYaml(
+            preamble = """
+                Test preamble
+
+                with an empty line
+            """.trimIndent(),
+        )
+
+        yaml shouldBe """
+            # Test preamble
+            #
+            # with an empty line
+
+            name: test
+            on:
+              push: {}
+            jobs:
+              test:
+                runs-on: ubuntu-latest
+                steps:
+                - id: step-0
+                  run: echo 'Hello!'
+
+        """.trimIndent()
+    }
+
     test("toYaml() - no preamble") {
         val yaml = workflowWithoutSource.toYaml(preamble = "")
 

--- a/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
@@ -13,6 +13,9 @@ import it.krzeminski.githubactions.domain.Concurrency
 import it.krzeminski.githubactions.domain.JobOutputs
 import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.Preamble.Just
+import it.krzeminski.githubactions.dsl.Preamble.WithOriginalAfter
+import it.krzeminski.githubactions.dsl.Preamble.WithOriginalBefore
 import it.krzeminski.githubactions.dsl.WorkflowBuilder
 import it.krzeminski.githubactions.dsl.expressions.Contexts
 import it.krzeminski.githubactions.dsl.expressions.expr
@@ -814,10 +817,12 @@ class IntegrationTest : FunSpec({
 
     test("toYaml() - custom preamble") {
         val yaml = workflowWithoutSource.toYaml(
-            preamble = """
-                Test preamble
-                with a second line
-            """.trimIndent(),
+            preamble = Just(
+                """
+                    Test preamble
+                    with a second line
+                """.trimIndent(),
+            ),
         )
 
         yaml shouldBe """
@@ -839,11 +844,13 @@ class IntegrationTest : FunSpec({
 
     test("toYaml() - custom preamble with empty line") {
         val yaml = workflowWithoutSource.toYaml(
-            preamble = """
-                Test preamble
+            preamble = Just(
+                """
+                    Test preamble
 
-                with an empty line
-            """.trimIndent(),
+                    with an empty line
+                """.trimIndent(),
+            ),
         )
 
         yaml shouldBe """
@@ -864,8 +871,140 @@ class IntegrationTest : FunSpec({
         """.trimIndent()
     }
 
+    test("toYaml() - custom preamble with original after") {
+        val yaml = workflow.toYaml(
+            addConsistencyCheck = false,
+            preamble = WithOriginalAfter(
+                """
+                    Test preamble
+                    with original after
+                """.trimIndent(),
+            ),
+        )
+
+        yaml shouldBe """
+            # Test preamble
+            # with original after
+
+            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+            # Generated with https://github.com/krzema12/github-workflows-kt
+
+            name: Test workflow
+            on:
+              push: {}
+            jobs:
+              test_job:
+                name: Test Job
+                runs-on: ubuntu-latest
+                steps:
+                - id: step-0
+                  uses: actions/checkout@v3
+                - id: step-1
+                  run: echo 'hello!'
+
+        """.trimIndent()
+    }
+
+    test("toYaml() - custom preamble with original after without source") {
+        val yaml = workflowWithoutSource.toYaml(
+            preamble = WithOriginalAfter(
+                """
+                    Test preamble
+                    with original after
+                """.trimIndent(),
+            ),
+        )
+
+        yaml shouldBe """
+            # Test preamble
+            # with original after
+
+            # This file was generated using a Kotlin DSL.
+            # If you want to modify the workflow, please change the Kotlin source and regenerate this YAML file.
+            # Generated with https://github.com/krzema12/github-workflows-kt
+
+            name: test
+            on:
+              push: {}
+            jobs:
+              test:
+                runs-on: ubuntu-latest
+                steps:
+                - id: step-0
+                  run: echo 'Hello!'
+
+        """.trimIndent()
+    }
+
+    test("toYaml() - custom preamble with original before") {
+        val yaml = workflow.toYaml(
+            addConsistencyCheck = false,
+            preamble = WithOriginalBefore(
+                """
+                    Test preamble
+                    with original before
+                """.trimIndent(),
+            ),
+        )
+
+        yaml shouldBe """
+            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+            # Generated with https://github.com/krzema12/github-workflows-kt
+
+            # Test preamble
+            # with original before
+
+            name: Test workflow
+            on:
+              push: {}
+            jobs:
+              test_job:
+                name: Test Job
+                runs-on: ubuntu-latest
+                steps:
+                - id: step-0
+                  uses: actions/checkout@v3
+                - id: step-1
+                  run: echo 'hello!'
+
+        """.trimIndent()
+    }
+
+    test("toYaml() - custom preamble with original before without source") {
+        val yaml = workflowWithoutSource.toYaml(
+            preamble = WithOriginalBefore(
+                """
+                    Test preamble
+                    with original before
+                """.trimIndent(),
+            ),
+        )
+
+        yaml shouldBe """
+            # This file was generated using a Kotlin DSL.
+            # If you want to modify the workflow, please change the Kotlin source and regenerate this YAML file.
+            # Generated with https://github.com/krzema12/github-workflows-kt
+
+            # Test preamble
+            # with original before
+
+            name: test
+            on:
+              push: {}
+            jobs:
+              test:
+                runs-on: ubuntu-latest
+                steps:
+                - id: step-0
+                  run: echo 'Hello!'
+
+        """.trimIndent()
+    }
+
     test("toYaml() - no preamble") {
-        val yaml = workflowWithoutSource.toYaml(preamble = "")
+        val yaml = workflowWithoutSource.toYaml(preamble = Just(""))
 
         yaml shouldBe """
             name: test

--- a/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
@@ -13,13 +13,13 @@ import it.krzeminski.githubactions.domain.Concurrency
 import it.krzeminski.githubactions.domain.JobOutputs
 import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.domain.triggers.Push
-import it.krzeminski.githubactions.dsl.Preamble.Just
-import it.krzeminski.githubactions.dsl.Preamble.WithOriginalAfter
-import it.krzeminski.githubactions.dsl.Preamble.WithOriginalBefore
 import it.krzeminski.githubactions.dsl.WorkflowBuilder
 import it.krzeminski.githubactions.dsl.expressions.Contexts
 import it.krzeminski.githubactions.dsl.expressions.expr
 import it.krzeminski.githubactions.dsl.workflow
+import it.krzeminski.githubactions.yaml.Preamble.Just
+import it.krzeminski.githubactions.yaml.Preamble.WithOriginalAfter
+import it.krzeminski.githubactions.yaml.Preamble.WithOriginalBefore
 import it.krzeminski.githubactions.yaml.toYaml
 import it.krzeminski.githubactions.yaml.writeToFile
 import java.nio.file.Path


### PR DESCRIPTION
- Do not add trailing whitespace in preamble
- Allow to insert the original preamble in a custom preamble

The placeholder name / form could be discussed.
I got inspired by lazy JSF EL expressions and dynamic Spock test names.
Something with `$` is bad, as it is a pita to escape in raw strings.
