### PR TITLE
chore(library): set Java version target to 11

### DIFF
--- a/.github/workflows/_shared.main.kts
+++ b/.github/workflows/_shared.main.kts
@@ -10,7 +10,7 @@ fun JobBuilder<*>.setupJava() =
     uses(
         name = "Set up JDK",
         action = SetupJavaV3(
-            javaVersion = "17",
+            javaVersion = "11",
             distribution = SetupJavaV3.Distribution.Zulu,
             cache = SetupJavaV3.BuildPlatform.Gradle,
         )

--- a/.github/workflows/actions-versions.yaml
+++ b/.github/workflows/actions-versions.yaml
@@ -34,7 +34,7 @@ jobs:
       name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 17
+        java-version: 11
         distribution: zulu
         cache: gradle
     - id: step-2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 17
+        java-version: 11
         distribution: zulu
         cache: gradle
     - id: step-2
@@ -52,7 +52,7 @@ jobs:
       name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 17
+        java-version: 11
         distribution: zulu
         cache: gradle
     - id: step-2

--- a/.github/workflows/check-if-wrappers-up-to-date.yaml
+++ b/.github/workflows/check-if-wrappers-up-to-date.yaml
@@ -34,7 +34,7 @@ jobs:
       name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 17
+        java-version: 11
         distribution: zulu
         cache: gradle
     - id: step-2
@@ -56,7 +56,7 @@ jobs:
       name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 17
+        java-version: 11
         distribution: zulu
         cache: gradle
     - id: step-2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
       name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 17
+        java-version: 11
         distribution: zulu
         cache: gradle
     - id: step-2

--- a/automation/typings/src/main/kotlin/it/krzeminski/githubactions/actionsmetadata/ActionsMetadataReading.kt
+++ b/automation/typings/src/main/kotlin/it/krzeminski/githubactions/actionsmetadata/ActionsMetadataReading.kt
@@ -12,6 +12,7 @@ import java.nio.file.Path
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.name
 import kotlin.io.path.readText
+import kotlin.streams.asSequence
 
 internal fun readActionsMetadata(): List<WrapperRequest> =
     readLocalActionTypings()
@@ -21,7 +22,7 @@ internal fun readActionsMetadata(): List<WrapperRequest> =
 private fun readLocalActionTypings(): List<WrapperRequest> {
     val actionTypingsDirectory = Path.of("actions")
 
-    return Files.walk(actionTypingsDirectory)
+    return Files.walk(actionTypingsDirectory).asSequence()
         .filter { it.isRegularFile() }
         .filter { it.name !in setOf("commit-hash.txt") }
         .map {

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
 }
 
 fun JavaToolchainSpec.requiredJdkVersion() {
-    languageVersion.set(JavaLanguageVersion.of(17))
+    languageVersion.set(JavaLanguageVersion.of(11))
 }
 
 tasks.withType<KotlinCompile> {


### PR DESCRIPTION
It's needed to synchronize the version with the Kotlin compiler. It's a prerequisite for using Gradle 8 (see #681).
Java 11 (and not some newer version) is used because its runtime is available without any extra
setup on GitHub Actions, so it makes it easier to use the library.