### PR TITLE
docs: Extract snippets from documentation to tested files and fix invalid examples (#195)

### DIFF
--- a/docs/user-guide/compensating-librarys-missing-features.md
+++ b/docs/user-guide/compensating-librarys-missing-features.md
@@ -16,18 +16,8 @@ needed, especially using basic types like booleans, strings or integers, and fur
 For example:
 
 ```kotlin
-workflow(
-    // ...
-    _customArguments = mapOf(
-        "dry-run" to true,
-        "some-string-value" to "foobar",
-        "written-by" to listOf("Alice", "Bob"),
-        "concurrency" to mapOf(
-            "group" to expr("github.ref"),
-            "cancel-in-progress" to "true",
-        ),
-    ),
-)
+--8<-- "CompensatingLibrarysMissingFeaturesSnippets.kt:customArguments1"
+--8<-- "CompensatingLibrarysMissingFeaturesSnippets.kt:customArguments2"
 ```
 
 ## Action's inputs
@@ -35,13 +25,8 @@ workflow(
 Each action wrapper has an extra constructor parameter - `_customInputs` - which is a map from `String` to `String`:
 
 ```kotlin
-UploadArtifactV3(
-    // ...
-    _customInputs = mapOf(
-        "path" to "override-path-value",
-        "answer" to "42",
-    ),
-)
+--8<-- "CompensatingLibrarysMissingFeaturesSnippets.kt:customInputs1"
+--8<-- "CompensatingLibrarysMissingFeaturesSnippets.kt:customInputs2"
 ```
 
 You can use it to set inputs that the wrapper doesn't know about, or to set any custom value if the wrapper's typing is
@@ -53,10 +38,8 @@ Each action wrapper has an extra constructor parameter - `_customVersion` - whic
 version:
 
 ```kotlin
-UploadArtifactV3(
-    // ...
-    _customVersion = "v4",
-)
+--8<-- "CompensatingLibrarysMissingFeaturesSnippets.kt:customVersion1"
+--8<-- "CompensatingLibrarysMissingFeaturesSnippets.kt:customVersion2"
 ```
 
 It's useful e.g. when the wrapper doesn't keep up with action's versions and the API is fairly compatible, or if you

--- a/docs/user-guide/compensating-librarys-missing-features.md
+++ b/docs/user-guide/compensating-librarys-missing-features.md
@@ -17,7 +17,7 @@ For example:
 
 ```kotlin
 workflow(
-    //...
+    // ...
     _customArguments = mapOf(
         "dry-run" to true,
         "some-string-value" to "foobar",
@@ -25,7 +25,7 @@ workflow(
         "concurrency" to mapOf(
             "group" to expr("github.ref"),
             "cancel-in-progress" to "true",
-        )
+        ),
     ),
 )
 ```
@@ -36,11 +36,11 @@ Each action wrapper has an extra constructor parameter - `_customInputs` - which
 
 ```kotlin
 UploadArtifactV3(
-    //...
+    // ...
     _customInputs = mapOf(
         "path" to "override-path-value",
         "answer" to "42",
-    )
+    ),
 )
 ```
 
@@ -54,8 +54,8 @@ version:
 
 ```kotlin
 UploadArtifactV3(
-    //...
-    _customVersion = "v4"
+    // ...
+    _customVersion = "v4",
 )
 ```
 

--- a/docs/user-guide/compensating-librarys-missing-features.md
+++ b/docs/user-guide/compensating-librarys-missing-features.md
@@ -35,7 +35,7 @@ workflow(
 Each action wrapper has an extra constructor parameter - `_customInputs` - which is a map from `String` to `String`:
 
 ```kotlin
-UploadArtifactV2(
+UploadArtifactV3(
     //...
     _customInputs = mapOf(
         "path" to "override-path-value",
@@ -53,9 +53,9 @@ Each action wrapper has an extra constructor parameter - `_customVersion` - whic
 version:
 
 ```kotlin
-UploadArtifactV2(
+UploadArtifactV3(
     //...
-    _customVersion = "v3"
+    _customVersion = "v4"
 )
 ```
 

--- a/docs/user-guide/getting_started.md
+++ b/docs/user-guide/getting_started.md
@@ -24,28 +24,9 @@ names with your own.
    GitHub Actions workflows.
 3. Put this content into the previously created file and save it:
    ```kotlin
-   #!/usr/bin/env kotlin
-
-   @file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:[[ version ]]")
-
-   import it.krzeminski.githubactions.actions.actions.CheckoutV3
-   import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
-   import it.krzeminski.githubactions.domain.triggers.Push
-   import it.krzeminski.githubactions.dsl.workflow
-   import it.krzeminski.githubactions.yaml.toYaml
-
-   val workflow = workflow(
-       name = "Test workflow",
-       on = listOf(Push()),
-       sourceFile = __FILE__.toPath(),
-   ) {
-       job(id = "test_job", runsOn = UbuntuLatest) {
-           uses(name = "Check out", action = CheckoutV3())
-           run(name = "Print greeting", command = "echo 'Hello world!'")
-       }
-   }
-
-   println(workflow.toYaml())
+   --8<-- "GettingStartedSnippets.kt:gettingStarted1"
+   --8<-- "GettingStartedSnippets.kt:gettingStarted2"
+   --8<-- "GettingStartedSnippets.kt:gettingStarted3"
    ```
    Explanation: first, we create a workflow with the DSL provided by this library. The reason it needs source
    file path is to be able to generate consistency checks, to ensure that both source and target files are in sync.

--- a/docs/user-guide/job-outputs.md
+++ b/docs/user-guide/job-outputs.md
@@ -6,37 +6,18 @@ are).
 First, define `outputs` parameter in `job` function, inheriting from `JobOutputs`:
 
 ```kotlin hl_lines="4-7"
-val myJob = job(
-    id = "my_job",
-    runsOn = RunnerType.UbuntuLatest,
-    outputs = object : JobOutputs() {
-        var myOutput by output()
-        var anotherOutput by output()
-    },
-) { ... }
+--8<-- "JobOutputsSnippets.kt:defineJobOutputs1"
+--8<-- "JobOutputsSnippets.kt:defineJobOutputs2"
 ```
 
 To set an output from within the job, use `jobOutputs`, and then an appropriate object field:
 
 ```kotlin
-jobOutputs.myOutput = someStep.outputs.someStepOutput
-jobOutputs.anotherOutput = someStep.outputs["custom-output"]
+--8<-- "JobOutputsSnippets.kt:setJobOutputs"
 ```
 
 and then use job's output from another job this way:
 
 ```kotlin hl_lines="9-10"
-job(
-    id = "use_output",
-    runsOn = RunnerType.UbuntuLatest,
-    needs = listOf(myJob),
-) {
-    run(
-        name = "Use outputs",
-        command = """
-            echo ${expr { myJob.outputs.myOutput }}
-            echo ${expr { myJob.outputs.anotherOutput }}
-        """.trimIndent(),
-    )
-}
+--8<-- "JobOutputsSnippets.kt:useJobOutputs"
 ```

--- a/docs/user-guide/job-outputs.md
+++ b/docs/user-guide/job-outputs.md
@@ -12,7 +12,7 @@ val myJob = job(
     outputs = object : JobOutputs() {
         var myOutput by output()
         var anotherOutput by output()
-    }
+    },
 ) { ... }
 ```
 

--- a/docs/user-guide/type-safe-expressions.md
+++ b/docs/user-guide/type-safe-expressions.md
@@ -23,7 +23,7 @@ run(
 )
 run(
     name = "GitHubContext echo sha",
-    command = "echo commit: \${{ github.sha256 }}  event: \${{ github.event.release.zip_url }}"
+    command = "echo commit: \${{ github.sha256 }}  event: \${{ github.event.release.zip_url }}",
 )
 ```
 
@@ -144,14 +144,14 @@ val FIRST_NAME by Contexts.env
 job(
     env = linkedMapOf(
         GREETING to "World",
-    )
+    ),
 ) {
     run(
         name = "Custom environment variable",
         env = linkedMapOf(
             FIRST_NAME to "Patrick",
         ),
-        command = "echo $GREETING $FIRST_NAME"
+        command = "echo $GREETING $FIRST_NAME",
     )
 }
 ```
@@ -181,9 +181,9 @@ job(id = "job1", runsOn = RunnerType.UbuntuLatest) {
         name = "Encrypted secret",
         env = linkedMapOf(
             SECRET to expr { SUPER_SECRET },
-            TOKEN to expr { secrets.GITHUB_TOKEN }
+            TOKEN to expr { secrets.GITHUB_TOKEN },
         ),
-        command = "echo secret=$SECRET token=$TOKEN"
+        command = "echo secret=$SECRET token=$TOKEN",
     )
 }
 ```

--- a/docs/user-guide/type-safe-expressions.md
+++ b/docs/user-guide/type-safe-expressions.md
@@ -16,15 +16,7 @@ They include:
 Here is an example
 
 ```kotlin
-run(
-    name = "Environment variable and functions",
-    command = "echo \$GITHUB_ACTORS",
-    condition = "\${{invariably()}}",
-)
-run(
-    name = "GitHubContext echo sha",
-    command = "echo commit: \${{ github.sha256 }}  event: \${{ github.event.release.zip_url }}",
-)
+--8<-- "TypeSafeExpressionsSnippets.kt:illExample"
 ```
 
 Unfortunately, it is easy to get those expressions wrong.
@@ -138,22 +130,8 @@ You can create your own type-safe property by using the syntax
 For example:
 
 ```kotlin
-val GREETING by Contexts.env
-val FIRST_NAME by Contexts.env
-
-job(
-    env = linkedMapOf(
-        GREETING to "World",
-    ),
-) {
-    run(
-        name = "Custom environment variable",
-        env = linkedMapOf(
-            FIRST_NAME to "Patrick",
-        ),
-        command = "echo $GREETING $FIRST_NAME",
-    )
-}
+--8<-- "TypeSafeExpressionsSnippets.kt:customEnvironmentVariables1"
+--8<-- "TypeSafeExpressionsSnippets.kt:customEnvironmentVariables2"
 ```
 
 Reference: https://docs.github.com/en/actions/learn-github-actions/environment-variables#about-environment-variables
@@ -171,21 +149,7 @@ You use them the same way as environment variables, but using `Contexts.secrets`
 For example:
 
 ```kotlin
-val SUPER_SECRET by Contexts.secrets
-
-val SECRET by Contexts.env
-val TOKEN by Contexts.env
-
-job(id = "job1", runsOn = RunnerType.UbuntuLatest) {
-    run(
-        name = "Encrypted secret",
-        env = linkedMapOf(
-            SECRET to expr { SUPER_SECRET },
-            TOKEN to expr { secrets.GITHUB_TOKEN },
-        ),
-        command = "echo secret=$SECRET token=$TOKEN",
-    )
-}
+--8<-- "TypeSafeExpressionsSnippets.kt:secrets"
 ```
 
 

--- a/docs/user-guide/type-safe-expressions.md
+++ b/docs/user-guide/type-safe-expressions.md
@@ -18,12 +18,12 @@ Here is an example
 ```kotlin
 run(
     name = "Environment variable and functions",
-    command = "echo \$GITHUB_ACTORS",  
-    condition = "\${{invariably()}}",  
+    command = "echo \$GITHUB_ACTORS",
+    condition = "\${{invariably()}}",
 )
-run(  
-    name = "GitHubContext echo sha",  
-    command = "echo commit: \${{ github.sha256 }}  event: \${{ github.event.release.zip_url }}"  
+run(
+    name = "GitHubContext echo sha",
+    command = "echo commit: \${{ github.sha256 }}  event: \${{ github.event.release.zip_url }}"
 )
 ```
 
@@ -121,7 +121,7 @@ They are available directly in the IDE via the library's `Contexts.env`
 By using this feature in our snippet we would have avoided escaping the dollar and the typo:
 
 ```diff
--command = "echo \$GITHUB_ACTORS",  
+-command = "echo \$GITHUB_ACTORS",
 +command = "echo " + Contexts.env.GITHUB_ACTOR,
 ```
 
@@ -138,19 +138,19 @@ You can create your own type-safe property by using the syntax
 For example:
 
 ```kotlin
-val GREETING by Contexts.env  
-val FIRST_NAME by Contexts.env  
+val GREETING by Contexts.env
+val FIRST_NAME by Contexts.env
 
-job(  
-    env = linkedMapOf(  
-        GREETING to "World",  
-    )  
-) {  
-    run(  
-        name = "Custom environment variable",  
-        env = linkedMapOf(  
-            FIRST_NAME to "Patrick",  
-        ),  
+job(
+    env = linkedMapOf(
+        GREETING to "World",
+    )
+) {
+    run(
+        name = "Custom environment variable",
+        env = linkedMapOf(
+            FIRST_NAME to "Patrick",
+        ),
         command = "echo $GREETING $FIRST_NAME"
     )
 }
@@ -171,19 +171,19 @@ You use them the same way as environment variables, but using `Contexts.secrets`
 For example:
 
 ```kotlin
-val SUPER_SECRET by Contexts.secrets  
+val SUPER_SECRET by Contexts.secrets
 
-val SECRET by Contexts.env  
+val SECRET by Contexts.env
 val TOKEN by Contexts.env
 
-job(id = "job1", runsOn = RunnerType.UbuntuLatest) {  
-    run(  
-        name = "Encrypted secret",  
-        env = linkedMapOf(  
-            SECRET to expr { SUPER_SECRET },  
-            TOKEN to expr { secrets.GITHUB_TOKEN }  
-        ),  
-        command = "echo secret=$SECRET token=$TOKEN"  
+job(id = "job1", runsOn = RunnerType.UbuntuLatest) {
+    run(
+        name = "Encrypted secret",
+        env = linkedMapOf(
+            SECRET to expr { SUPER_SECRET },
+            TOKEN to expr { secrets.GITHUB_TOKEN }
+        ),
+        command = "echo secret=$SECRET token=$TOKEN"
     )
 }
 ```
@@ -198,4 +198,3 @@ There are more `github.event` payloads that we currently do not support: https:/
 We feel what we have is a pretty good start, but if you need an additional feature, you can [create an issue](https://github.com/krzema12/github-workflows-kt/issues)
 
 Or maybe have a look how this type-safe feature is implemented in [it.krzeminski.githubactions.dsl.expressions](https://github.com/krzema12/github-workflows-kt/tree/main/library/src/main/kotlin/it/krzeminski/githubactions/dsl/expressions) and [submit a pull request 🙏🏻](https://github.com/krzema12/github-workflows-kt/pulls)
-

--- a/docs/user-guide/type-safe-expressions.md
+++ b/docs/user-guide/type-safe-expressions.md
@@ -166,7 +166,7 @@ If you have sensitive information, you should store it as a GitHub secret:
 
 You use them the same way as environment variables, but using `Contexts.secrets` instead of `Contexts.env`:
 
-> val SUPER_SECRET by Contexts.secrets
+> `val SUPER_SECRET by Contexts.secrets`
 
 For example:
 

--- a/docs/user-guide/using-actions.md
+++ b/docs/user-guide/using-actions.md
@@ -44,42 +44,20 @@ Inherit from [`Action`](https://github.com/krzema12/github-workflows-kt/blob/mai
 and in case of actions without explicit outputs, use the `Actions.Outputs` class as type argument:
 
 ```kotlin
-class MyCoolActionV3(
-    private val someArgument: String,
-) : Action<Action.Outputs>("acmecorp", "cool-action", "v3") {
-    override fun toYamlArguments() = linkedMapOf(
-        "some-argument" to someArgument,
-    )
-
-    override fun buildOutputObject(stepId: String) = Outputs(stepId)
-}
+--8<-- "UsingActionsSnippets.kt:actionWithoutOutputs"
 ```
 
 or, in case of actions with explicit outputs, create a subclass of `Action.Outputs` for the type argument:
 
 ```kotlin
-class MyCoolActionV3(
-    private val someArgument: String,
-) : Action<MyCoolActionV3.Outputs>("acmecorp", "cool-action", "v3") {
-    override fun toYamlArguments() = linkedMapOf(
-        "some-argument" to someArgument,
-    )
-
-    override fun buildOutputObject(stepId: String) = Outputs(stepId)
-
-    class Outputs(stepId: String) : Action.Outputs(stepId) {
-        public val coolOutput: String = "steps.$stepId.outputs.coolOutput"
-    }
-}
+--8<-- "UsingActionsSnippets.kt:actionWithOutputs1"
+--8<-- "UsingActionsSnippets.kt:actionWithOutputs2"
 ```
 
 Once you've got your action, it's now as simple as using it like this:
 
 ```kotlin
-uses(
-    name = "FooBar",
-    action = MyCoolActionV3(someArgument = "foobar"),
-)
+--8<-- "UsingActionsSnippets.kt:using"
 ```
 
 ### Untyped wrapper
@@ -92,27 +70,11 @@ uses(
 Use a [`CustomAction`](https://github.com/krzema12/github-workflows-kt/blob/main/library/src/main/kotlin/it/krzeminski/githubactions/actions/CustomAction.kt):
 
 ```kotlin
-val customAction = CustomAction(
-    actionOwner = "xu-cheng",
-    actionName = "latex-action",
-    actionVersion = "v2",
-    inputs = linkedMapOf(
-        "root_file" to "report.tex",
-        "compiler" to "latexmk",
-    ),
-)
+--8<-- "UsingActionsSnippets.kt:customAction"
 ```
 
 If your custom action has outputs, you can access them, albeit in a type-unsafe manner:
 
 ```kotlin
-job("test_job", runsOn = RunnerType.UbuntuLatest) {
-    val customActionStep = uses(
-        name = "Some step with output",
-        action = customAction,
-    )
-    
-    // use your outputs:
-    println(expr(customActionStep.outputs["custom-output"]))
-}
+--8<-- "UsingActionsSnippets.kt:customActionOutputs"
 ```

--- a/docs/user-guide/using-actions.md
+++ b/docs/user-guide/using-actions.md
@@ -76,8 +76,10 @@ class MyCoolActionV3(
 Once you've got your action, it's now as simple as using it like this:
 
 ```kotlin
-uses(name = "FooBar",
-     action = MyCoolActionV3(someArgument = "foobar"))
+uses(
+    name = "FooBar",
+    action = MyCoolActionV3(someArgument = "foobar"),
+)
 ```
 
 ### Untyped wrapper
@@ -97,7 +99,7 @@ val customAction = CustomAction(
     inputs = linkedMapOf(
         "root_file" to "report.tex",
         "compiler" to "latexmk",
-    )
+    ),
 )
 ```
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -71,6 +71,10 @@ val validateDuplicatedVersion by tasks.creating<Task> {
             project.rootDir.resolve("script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/Version.kt").readText()
                 .contains("val LIBRARY_VERSION = \"$version\"")
         ) { "Library version stated in script-generator/.../Version.kt should be equal to $version!" }
+        require(
+            project.file("src/test/kotlin/it/krzeminski/githubactions/docsnippets/GettingStartedSnippets.kt").readText()
+                .contains("\"it.krzeminski:github-actions-kotlin-dsl:$version\"")
+        ) { "Library version stated in library/src/test/.../GettingStarted.kt should be equal to $version!" }
     }
 }
 

--- a/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/CompensatingLibrarysMissingFeaturesSnippets.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/CompensatingLibrarysMissingFeaturesSnippets.kt
@@ -1,0 +1,69 @@
+package it.krzeminski.githubactions.docsnippets
+
+import io.kotest.core.spec.style.FunSpec
+import it.krzeminski.githubactions.actions.actions.UploadArtifactV3
+import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.expressions.expr
+import it.krzeminski.githubactions.dsl.workflow
+
+class CompensatingLibrarysMissingFeaturesSnippets : FunSpec({
+    test("customArguments") {
+/* ktlint-disable indent */
+// --8<-- [start:customArguments1]
+workflow(
+// --8<-- [end:customArguments1]
+    name = "customArguments",
+    on = listOf(Push()),
+// --8<-- [start:customArguments2]
+    // ...
+    _customArguments = mapOf(
+        "dry-run" to true,
+        "some-string-value" to "foobar",
+        "written-by" to listOf("Alice", "Bob"),
+        "concurrency" to mapOf(
+            "group" to expr("github.ref"),
+            "cancel-in-progress" to "true",
+        ),
+    ),
+)
+// --8<-- [end:customArguments2]
+{
+    job(id = "test_job", runsOn = UbuntuLatest) {
+        run(command = "echo 'Hello world!'")
+    }
+}
+/* ktlint-enable indent */
+    }
+
+    test("customInputs") {
+/* ktlint-disable indent */
+// --8<-- [start:customInputs1]
+UploadArtifactV3(
+// --8<-- [end:customInputs1]
+    path = emptyList(),
+// --8<-- [start:customInputs2]
+    // ...
+    _customInputs = mapOf(
+        "path" to "override-path-value",
+        "answer" to "42",
+    ),
+)
+// --8<-- [end:customInputs2]
+/* ktlint-enable indent */
+    }
+
+    test("customVersion") {
+/* ktlint-disable indent */
+// --8<-- [start:customVersion1]
+UploadArtifactV3(
+// --8<-- [end:customVersion1]
+    path = emptyList(),
+// --8<-- [start:customVersion2]
+    // ...
+    _customVersion = "v4",
+)
+// --8<-- [end:customVersion2]
+/* ktlint-enable indent */
+    }
+},)

--- a/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/GettingStartedSnippets.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/GettingStartedSnippets.kt
@@ -1,0 +1,45 @@
+package it.krzeminski.githubactions.docsnippets
+
+/* ktlint-disable import-ordering */
+import io.kotest.core.spec.style.FunSpec
+// --8<-- [start:gettingStarted2]
+import it.krzeminski.githubactions.actions.actions.CheckoutV3
+import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.workflow
+import it.krzeminski.githubactions.yaml.toYaml
+// --8<-- [end:gettingStarted2]
+import java.io.File
+/* ktlint-enable import-ordering */
+
+class GettingStartedSnippets : FunSpec({
+    test("gettingStarted") {
+/* ktlint-disable indent */
+/*
+// --8<-- [start:gettingStarted1]
+#!/usr/bin/env kotlin
+
+@file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:0.36.0")
+
+// --8<-- [end:gettingStarted1]
+*/
+@Suppress("VariableNaming")
+val __FILE__ = File("")
+// --8<-- [start:gettingStarted3]
+
+val workflow = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    sourceFile = __FILE__.toPath(),
+) {
+    job(id = "test_job", runsOn = UbuntuLatest) {
+        uses(name = "Check out", action = CheckoutV3())
+        run(name = "Print greeting", command = "echo 'Hello world!'")
+    }
+}
+
+println(workflow.toYaml())
+// --8<-- [end:gettingStarted3]
+/* ktlint-enable indent */
+    }
+},)

--- a/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/JobOutputsSnippets.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/JobOutputsSnippets.kt
@@ -1,0 +1,67 @@
+package it.krzeminski.githubactions.docsnippets
+
+import io.kotest.core.spec.style.FunSpec
+import it.krzeminski.githubactions.domain.JobOutputs
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.actions.Action
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.expressions.expr
+import it.krzeminski.githubactions.dsl.workflow
+import java.util.LinkedHashMap
+
+class JobOutputsSnippets : FunSpec({
+    test("jobOutputs") {
+        workflow(
+            name = "Test workflow",
+            on = listOf(Push()),
+        ) {
+/* ktlint-disable indent */
+// --8<-- [start:defineJobOutputs1]
+val myJob = job(
+    id = "my_job",
+    runsOn = RunnerType.UbuntuLatest,
+    outputs = object : JobOutputs() {
+        var myOutput by output()
+        var anotherOutput by output()
+    },
+// --8<-- [end:defineJobOutputs1]
+/*
+// --8<-- [start:defineJobOutputs2]
+) { ... }
+// --8<-- [end:defineJobOutputs2]
+*/
+) {
+    class DocTest : Action<DocTest.Outputs>("doc", "test", "v0") {
+        override fun toYamlArguments(): LinkedHashMap<String, String> = linkedMapOf()
+        override fun buildOutputObject(stepId: String): Outputs = Outputs(stepId)
+        inner class Outputs(stepId: String) : Action.Outputs(stepId) {
+            val someStepOutput: String = ""
+        }
+    }
+    val someStep = uses(DocTest())
+
+// --8<-- [start:setJobOutputs]
+jobOutputs.myOutput = someStep.outputs.someStepOutput
+jobOutputs.anotherOutput = someStep.outputs["custom-output"]
+// --8<-- [end:setJobOutputs]
+}
+
+// --8<-- [start:useJobOutputs]
+job(
+    id = "use_output",
+    runsOn = RunnerType.UbuntuLatest,
+    needs = listOf(myJob),
+) {
+    run(
+        name = "Use outputs",
+        command = """
+            echo ${expr { myJob.outputs.myOutput }}
+            echo ${expr { myJob.outputs.anotherOutput }}
+        """.trimIndent(),
+    )
+}
+// --8<-- [end:useJobOutputs]
+/* ktlint-enable indent */
+        }
+    }
+},)

--- a/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/TypeSafeExpressionsSnippets.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/TypeSafeExpressionsSnippets.kt
@@ -1,0 +1,97 @@
+@file:Suppress("VariableNaming")
+
+package it.krzeminski.githubactions.docsnippets
+
+import io.kotest.core.spec.style.FunSpec
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.expressions.Contexts
+import it.krzeminski.githubactions.dsl.expressions.expr
+import it.krzeminski.githubactions.dsl.workflow
+
+class TypeSafeExpressionsSnippets : FunSpec({
+    test("illExample") {
+        workflow(
+            name = "Test workflow",
+            on = listOf(Push()),
+        ) {
+            job(
+                id = "test_job",
+                runsOn = RunnerType.UbuntuLatest,
+            ) {
+/* ktlint-disable indent */
+// --8<-- [start:illExample]
+run(
+    name = "Environment variable and functions",
+    command = "echo \$GITHUB_ACTORS",
+    condition = "\${{invariably()}}",
+)
+run(
+    name = "GitHubContext echo sha",
+    command = "echo commit: \${{ github.sha256 }}  event: \${{ github.event.release.zip_url }}",
+)
+// --8<-- [end:illExample]
+/* ktlint-enable indent */
+            }
+        }
+    }
+
+    test("customEnvironmentVariables") {
+        workflow(
+            name = "Test workflow",
+            on = listOf(Push()),
+        ) {
+/* ktlint-disable indent */
+// --8<-- [start:customEnvironmentVariables1]
+val GREETING by Contexts.env
+val FIRST_NAME by Contexts.env
+
+job(
+// --8<-- [end:customEnvironmentVariables1]
+    id = "job0",
+    runsOn = RunnerType.UbuntuLatest,
+// --8<-- [start:customEnvironmentVariables2]
+    env = linkedMapOf(
+        GREETING to "World",
+    ),
+) {
+    run(
+        name = "Custom environment variable",
+        env = linkedMapOf(
+            FIRST_NAME to "Patrick",
+        ),
+        command = "echo $GREETING $FIRST_NAME",
+    )
+}
+// --8<-- [end:customEnvironmentVariables2]
+/* ktlint-enable indent */
+        }
+    }
+
+    test("secrets") {
+        workflow(
+            name = "Test workflow",
+            on = listOf(Push()),
+        ) {
+/* ktlint-disable indent */
+// --8<-- [start:secrets]
+val SUPER_SECRET by Contexts.secrets
+
+val SECRET by Contexts.env
+val TOKEN by Contexts.env
+
+job(id = "job1", runsOn = RunnerType.UbuntuLatest) {
+    run(
+        name = "Encrypted secret",
+        env = linkedMapOf(
+            SECRET to expr { SUPER_SECRET },
+            TOKEN to expr { secrets.GITHUB_TOKEN },
+        ),
+        command = "echo secret=$SECRET token=$TOKEN",
+    )
+}
+// --8<-- [end:secrets]
+/* ktlint-enable indent */
+        }
+    }
+},)

--- a/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/UsingActionsSnippets.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/UsingActionsSnippets.kt
@@ -1,0 +1,101 @@
+package it.krzeminski.githubactions.docsnippets
+
+import io.kotest.core.spec.style.FunSpec
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.actions.Action
+import it.krzeminski.githubactions.domain.actions.CustomAction
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.expressions.expr
+import it.krzeminski.githubactions.dsl.workflow
+
+class UsingActionsSnippets : FunSpec({
+    test("actionWithoutOutputs") {
+/* ktlint-disable indent */
+// --8<-- [start:actionWithoutOutputs]
+class MyCoolActionV3(
+    private val someArgument: String,
+) : Action<Action.Outputs>("acmecorp", "cool-action", "v3") {
+    override fun toYamlArguments() = linkedMapOf(
+        "some-argument" to someArgument,
+    )
+
+    override fun buildOutputObject(stepId: String) = Outputs(stepId)
+}
+// --8<-- [end:actionWithoutOutputs]
+/* ktlint-enable indent */
+    }
+
+    test("actionWithOutputs") {
+/* ktlint-disable indent */
+// --8<-- [start:actionWithOutputs1]
+class MyCoolActionV3(
+    private val someArgument: String,
+) : Action<MyCoolActionV3.Outputs>("acmecorp", "cool-action", "v3") {
+    override fun toYamlArguments() = linkedMapOf(
+        "some-argument" to someArgument,
+    )
+
+    override fun buildOutputObject(stepId: String) = Outputs(stepId)
+
+// --8<-- [end:actionWithOutputs1]
+    inner
+// --8<-- [start:actionWithOutputs2]
+    class Outputs(stepId: String) : Action.Outputs(stepId) {
+        public val coolOutput: String = "steps.$stepId.outputs.coolOutput"
+    }
+}
+// --8<-- [end:actionWithOutputs2]
+/* ktlint-enable indent */
+
+        workflow(
+            name = "Test workflow",
+            on = listOf(Push()),
+        ) {
+            job(id = "test-job", runsOn = RunnerType.UbuntuLatest) {
+/* ktlint-disable indent */
+// --8<-- [start:using]
+uses(
+    name = "FooBar",
+    action = MyCoolActionV3(someArgument = "foobar"),
+)
+// --8<-- [end:using]
+/* ktlint-enable indent */
+            }
+        }
+    }
+
+    test("customAction") {
+/* ktlint-disable indent */
+// --8<-- [start:customAction]
+val customAction = CustomAction(
+    actionOwner = "xu-cheng",
+    actionName = "latex-action",
+    actionVersion = "v2",
+    inputs = linkedMapOf(
+        "root_file" to "report.tex",
+        "compiler" to "latexmk",
+    ),
+)
+// --8<-- [end:customAction]
+/* ktlint-enable indent */
+
+        workflow(
+            name = "Test workflow",
+            on = listOf(Push()),
+        ) {
+/* ktlint-disable indent */
+// --8<-- [start:customActionOutputs]
+job("test_job", runsOn = RunnerType.UbuntuLatest) {
+    val customActionStep = uses(
+        name = "Some step with output",
+        action = customAction,
+    )
+
+    // use your outputs:
+    println(expr(customActionStep.outputs["custom-output"]))
+}
+// --8<-- [end:customActionOutputs]
+/* ktlint-enable indent */
+        }
+    }
+},)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,10 @@ markdown_extensions:
   - pymdownx.magiclink
   - pymdownx.inlinehilite
   - pymdownx.superfences
+  - pymdownx.snippets:
+      base_path:
+        - library/src/test/kotlin/it/krzeminski/githubactions/docsnippets
+      check_paths: True
   - admonition
 
 plugins:


### PR DESCRIPTION
Fixes: #195

Contentwise changes in the snippets:
- removed some trailing whitespace
- added an inline code highlighting
- replaced deprecated action with its current version
- fixed all the ktlint findings in the snippets

Everything else is currently identical to the previous outcome.
