### PR TITLE
[#719] fix(wrapper-generator): forbid unknown properties in typing YAML

### DIFF
--- a/automation/typings/src/main/kotlin/it/krzeminski/githubactions/actionsmetadata/ActionsMetadataReading.kt
+++ b/automation/typings/src/main/kotlin/it/krzeminski/githubactions/actionsmetadata/ActionsMetadataReading.kt
@@ -69,6 +69,7 @@ private fun buildTypingsSource(
 
 private val myYaml = Yaml(
     configuration = Yaml.default.configuration.copy(
-        strictMode = false,
+        // Don't allow any unknown keys, to keep the YAMLs minimal.
+        strictMode = true,
     ),
 )


### PR DESCRIPTION
Closes #719.