### PR TITLE
fix: remove leftover ktlint violations

### DIFF
--- a/automation/typings/src/test/kotlin/it/krzeminski/githubactions/actionsmetadata/AddDeprecationInfoTest.kt
+++ b/automation/typings/src/test/kotlin/it/krzeminski/githubactions/actionsmetadata/AddDeprecationInfoTest.kt
@@ -22,4 +22,4 @@ class AddDeprecationInfoTest : FunSpec({
             WrapperRequest(ActionCoords("owner", "other-name", "v3")),
         )
     }
-},)
+})

--- a/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/ClassNamingTest.kt
+++ b/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/ClassNamingTest.kt
@@ -16,4 +16,4 @@ class ClassNamingTest : FunSpec({
             }
         }
     }
-},)
+})

--- a/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/GenerationTest.kt
+++ b/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/GenerationTest.kt
@@ -352,4 +352,4 @@ class GenerationTest : FunSpec({
         // then
         wrapper.shouldMatchFile("ActionWithInputsSharingTypeV3.kt")
     }
-},)
+})

--- a/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/InputNullabilityTest.kt
+++ b/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/InputNullabilityTest.kt
@@ -30,4 +30,4 @@ class InputNullabilityTest : FunSpec({
             }
         }
     }
-},)
+})

--- a/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/TextTransformationTest.kt
+++ b/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/TextTransformationTest.kt
@@ -43,4 +43,4 @@ class TextTransformationTest : FunSpec({
             }
         }
     }
-},)
+})

--- a/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/TypingSuggestionsTest.kt
+++ b/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/TypingSuggestionsTest.kt
@@ -58,4 +58,4 @@ class TypingSuggestionsTest : FunSpec({
             |    )
         """.trimMargin()
     }
-},)
+})

--- a/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/types/TypesProvidingTest.kt
+++ b/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/types/TypesProvidingTest.kt
@@ -70,4 +70,4 @@ class TypesProvidingTest : FunSpec({
             "permissions" to EnumTyping("Permissions", listOf("user", "admin", "guest")),
         )
     }
-},)
+})

--- a/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/versions/SuggestVersionsTest.kt
+++ b/automation/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/versions/SuggestVersionsTest.kt
@@ -86,4 +86,4 @@ class SuggestVersionsTest : FunSpec({
             }
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
@@ -1019,7 +1019,7 @@ class IntegrationTest : FunSpec({
 
         """.trimIndent()
     }
-},)
+})
 
 private fun testRanWithGitHub(
     name: String,

--- a/library/src/test/kotlin/it/krzeminski/githubactions/actions/CustomActionTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/actions/CustomActionTest.kt
@@ -24,4 +24,4 @@ class CustomActionTest : FunSpec({
         // when & then
         outputs["custom-output"] shouldBe "steps.someStepId.outputs.custom-output"
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/CompensatingLibrarysMissingFeaturesSnippets.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/CompensatingLibrarysMissingFeaturesSnippets.kt
@@ -60,4 +60,4 @@ class CompensatingLibrarysMissingFeaturesSnippets : FunSpec({
         )
         // --8<-- [end:custom-version-2]
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/GettingStartedSnippets.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/GettingStartedSnippets.kt
@@ -40,4 +40,4 @@ class GettingStartedSnippets : FunSpec({
         println(workflow.toYaml())
         // --8<-- [end:getting-started-3]
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/JobOutputsSnippets.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/JobOutputsSnippets.kt
@@ -62,4 +62,4 @@ class JobOutputsSnippets : FunSpec({
             // --8<-- [end:use-job-outputs]
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/TypeSafeExpressionsSnippets.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/TypeSafeExpressionsSnippets.kt
@@ -88,4 +88,4 @@ class TypeSafeExpressionsSnippets : FunSpec({
             // --8<-- [end:secrets]
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/UsingActionsSnippets.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/docsnippets/UsingActionsSnippets.kt
@@ -88,4 +88,4 @@ class UsingActionsSnippets : FunSpec({
             // --8<-- [end:custom-action-outputs]
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/domain/JobTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/domain/JobTest.kt
@@ -113,4 +113,4 @@ class JobTest : FunSpec({
             )
         } shouldHaveMessage "timeout should be positive"
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/domain/triggers/OtherTriggersTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/domain/triggers/OtherTriggersTest.kt
@@ -161,4 +161,4 @@ class OtherTriggersTest : FunSpec({
             "workflow_run" to mapOf("types" to listOf("completed", "requested")),
         )
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/domain/triggers/PullRequestTargetTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/domain/triggers/PullRequestTargetTest.kt
@@ -26,4 +26,4 @@ class PullRequestTargetTest : FunSpec({
             exception.message shouldBe "Cannot define both 'paths' and 'pathsIgnore'!"
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/domain/triggers/PullRequestTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/domain/triggers/PullRequestTest.kt
@@ -26,4 +26,4 @@ class PullRequestTest : FunSpec({
             exception.message shouldBe "Cannot define both 'paths' and 'pathsIgnore'!"
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/domain/triggers/PushTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/domain/triggers/PushTest.kt
@@ -36,4 +36,4 @@ class PushTest : FunSpec({
             exception.message shouldBe "Cannot define both 'paths' and 'pathsIgnore'!"
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/domain/triggers/ScheduleTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/domain/triggers/ScheduleTest.kt
@@ -65,4 +65,4 @@ class ScheduleTest : FunSpec({
             )
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/dsl/JobBuilderTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/dsl/JobBuilderTest.kt
@@ -61,4 +61,4 @@ class JobBuilderTest : FunSpec({
             }
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilderTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilderTest.kt
@@ -122,4 +122,4 @@ class WorkflowBuilderTest : FunSpec({
             exception.message shouldBe "Duplicated job names: [Some-job-1, Some-job-3]"
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/dsl/expressions/ContextsTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/dsl/expressions/ContextsTest.kt
@@ -102,4 +102,4 @@ class ContextsTest : FunSpec({
             expr { github.eventPush.repository.size } shouldBe expr("github.event.repository.size")
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/dsl/expressions/PayloadTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/dsl/expressions/PayloadTest.kt
@@ -22,7 +22,7 @@ class PayloadTest : FunSpec({
 
         context.properties() shouldMatch jsonObject.keys.sorted()
     }
-},)
+})
 
 infix fun List<String>.shouldMatch(other: List<String>) {
     if (this.toSet() != other.toSet()) {

--- a/library/src/test/kotlin/it/krzeminski/githubactions/yaml/CaseTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/yaml/CaseTest.kt
@@ -31,7 +31,7 @@ class CaseTest : DescribeSpec({
         PullRequestTarget.Type.values().forAll { it.toSnakeCase() }
         PullRequest.Type.values().forAll { it.toSnakeCase() }
     }
-},)
+})
 
 private enum class MyEnum {
     In_valid, // ktlint-disable enum-entry-name-case

--- a/library/src/test/kotlin/it/krzeminski/githubactions/yaml/JobsToYamlTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/yaml/JobsToYamlTest.kt
@@ -322,4 +322,4 @@ class JobsToYamlTest : DescribeSpec({
             ),
         )
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/yaml/ObjectToYamlTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/yaml/ObjectToYamlTest.kt
@@ -125,4 +125,4 @@ class ObjectToYamlTest : DescribeSpec({
 
         """.trimIndent()
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/yaml/StepsToYamlTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/yaml/StepsToYamlTest.kt
@@ -418,4 +418,4 @@ class StepsToYamlTest : DescribeSpec({
             )
         }
     }
-},)
+})

--- a/library/src/test/kotlin/it/krzeminski/githubactions/yaml/TriggersToYamlTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/yaml/TriggersToYamlTest.kt
@@ -407,4 +407,4 @@ class TriggersToYamlTest : DescribeSpec({
             ),
         )
     }
-},)
+})

--- a/script-generator/src/test/kotlin/it/krzeminski/githubactions/scriptgenerator/ImportsTest.kt
+++ b/script-generator/src/test/kotlin/it/krzeminski/githubactions/scriptgenerator/ImportsTest.kt
@@ -42,4 +42,4 @@ class ImportsTest : FunSpec({
             content.contains(import).shouldBeTrue()
         }
     }
-},)
+})

--- a/script-generator/src/test/kotlin/test/EnumsTest.kt
+++ b/script-generator/src/test/kotlin/test/EnumsTest.kt
@@ -48,4 +48,4 @@ class EnumsTest : FunSpec({
             "runsOn = it.krzeminski.githubactions.domain.RunnerType.Custom(expr(\"github.event.inputs.run-on || 'ubuntu-latest'\")),\n",
         )
     }
-},)
+})

--- a/script-generator/src/test/kotlin/test/GenerateKotlinScripts.kt
+++ b/script-generator/src/test/kotlin/test/GenerateKotlinScripts.kt
@@ -40,7 +40,7 @@ class GenerateKotlinScripts : FunSpec({
             }
         }
     }
-},)
+})
 
 data class TestInput(val name: String) {
     val filename = name.removeSuffix(".yml")

--- a/script-generator/src/test/kotlin/test/KotlinPoetTest.kt
+++ b/script-generator/src/test/kotlin/test/KotlinPoetTest.kt
@@ -114,4 +114,4 @@ class KotlinPoetTest : DescribeSpec({
                 .toString() shouldBe ""
         }
     }
-},)
+})

--- a/script-generator/src/test/kotlin/test/NormalizeYamlTest.kt
+++ b/script-generator/src/test/kotlin/test/NormalizeYamlTest.kt
@@ -120,4 +120,4 @@ class NormalizeYamlTest : FunSpec({
                   cancel-in-progress: false
         """.trimIndent()
     }
-},)
+})

--- a/script-generator/src/test/kotlin/test/RunKotlinScripts.kt
+++ b/script-generator/src/test/kotlin/test/RunKotlinScripts.kt
@@ -35,4 +35,4 @@ class RunKotlinScripts : FunSpec({
                 .writeToFile(addConsistencyCheck = false)
         }
     }
-},)
+})

--- a/script-generator/src/test/kotlin/test/TypingsTest.kt
+++ b/script-generator/src/test/kotlin/test/TypingsTest.kt
@@ -72,4 +72,4 @@ class TypingsTest : FunSpec({
             valueWithTyping(value, typing, coords).toString() shouldBe expected
         }
     }
-},)
+})


### PR DESCRIPTION
I mistakenly merged the previous PR that pointed to these violations
because I thought there's something wrong with Gradle cache.
It turned out that these are different violations.